### PR TITLE
Fixing routes

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -19,9 +19,9 @@
 <!-- 5. Update visible pages depending on whether or not the user is logged in -->
 <script>
 
-  let privatePages = ['/profile', '/', '/logout'];
+  let privatePages = ['/profile/', '/', '/logout/'];
 
-  let publicPages = ['/login']
+  let publicPages = ['/login/']
 
   const loginElement = document.querySelector("#login")
   const profileElement = document.querySelector("#profile")
@@ -86,7 +86,7 @@
         .logout();
       window
         .location
-        .replace("http://localhost:8080/login");
+        .replace("/login");
     } catch (error) {
       // Handle errors if required!
       console.log('Ran into this error while logging out: ', error);


### PR DESCRIPTION
With these changes, a logged-in user will be redirected to the home page when visiting `/login`. Also, a logged out user won't be able to visit the protected pages by typing manually.